### PR TITLE
Remove empty arguments before invoking compiler

### DIFF
--- a/lib/cc.tcl
+++ b/lib/cc.tcl
@@ -512,9 +512,6 @@ proc cctest {args} {
 		lappend cmdline {*}[get-define LIBS]
 	}
 
-	# Remove any empty arguments from the command line.
-	set cmdline [lmap x $cmdline { expr {$x eq {} ? [break] : $x}}]
-
 	# At this point we have the complete command line and the
 	# complete source to be compiled. Get the result from cache if
 	# we can

--- a/lib/cc.tcl
+++ b/lib/cc.tcl
@@ -512,6 +512,9 @@ proc cctest {args} {
 		lappend cmdline {*}[get-define LIBS]
 	}
 
+	# Remove any empty arguments from the command line.
+	set cmdline [lmap x $cmdline { expr {$x eq {} ? [break] : $x}}]
+
 	# At this point we have the complete command line and the
 	# complete source to be compiled. Get the result from cache if
 	# we can

--- a/lib/cc.tcl
+++ b/lib/cc.tcl
@@ -325,6 +325,9 @@ proc cc-add-settings {settings} {
 	array set new $prev
 
 	foreach {name value} $settings {
+		if {$value eq {}} {
+			continue
+		}
 		switch -exact -- $name {
 			-cflags - -includes {
 				# These are given as lists


### PR DESCRIPTION
I am having a problem with a malformed compiler command line coming from the
fact that I am looping over a set of variable and trying different combinations.
This comes from a module I'm writing which is supposed to locate iconv() either
i) in prefix, ii) in a dedicated libiconv.so library, or iii) in libc.
I am looping over different variations of cflags, ldflags, and libs, any of
which could be empty in a particular iteration. When this happens, the compiler
gets invoked with empty arguments, which end up in it erroring with "No such
file".

The proposed commits cleans up the command line by removing empty arguments
before executing it.

```tcl
  #                     prefix            noprefix  libc
  set i_msg_l     [list $prefix           libiconv  libc]
  set i_cflags_l  [list -I$prefix/include {}        {}  ]
  set i_ldflags_l [list -L$prefix/lib     {}        {}  ]
  set i_libs_l    [list -liconv           -liconv   {}  ]

  foreach i_msg $i_msg_l i_cflags $i_cflags_l i_ldflags $i_ldflags_l i_libs $i_libs_l {
    msg-checking "Checking for iconv() in $i_msg..."
    if {[cctest -cflags $i_cflags -libs [list $i_ldflags $i_libs] -link 1 \
                -includes $iconv_inc -code $iconv_code]} {
      do_something
    }
  }
```