### PR TITLE
Added $::autosetup(opthelpline) dict

### DIFF
--- a/autosetup
+++ b/autosetup
@@ -79,6 +79,7 @@ proc main {argv} {
 	# options-defaults is a dictionary of overrides for default values for options
 	set autosetup(options-defaults) {}
 	set autosetup(optionhelp) {}
+	set autosetup(opthelpline) {}
 	set autosetup(showhelp) 0
 
 	# Parse options
@@ -512,6 +513,7 @@ proc options-add {opts {header ""}} {
 			}
 			# A multi-line description
 			lappend autosetup(optionhelp) $opthelp $desc
+			dict set autosetup(opthelpline) $name $desc
 			incr i 2
 		}
 	}


### PR DESCRIPTION
This collects the option help text strings passed to options() from
auto.def so that the auto.def script can later access them
programmatically, rather than perpetrate a DRY violation.

Use case: a project may have an external script that takes a subset of
the same options that the configure script takes so a loop in auto.def
extracts the needed options and writes them (along with the help
strings) to a file that the other script can read directly, rather than
require that the other script parse auto.def.

You can see this in use in [the PiDP-8/I software project](https://tangentsoft.com/pidp8i/) where the "external script" in question is libexec/mkos8, a Python helper script. Feel free to adjust the mechanism: I'll pull and merge as necessary, so long as I can access the help strings by option name.