### PR TITLE
Allow comments after @else/@endif

### DIFF
--- a/lib/system.tcl
+++ b/lib/system.tcl
@@ -183,7 +183,7 @@ proc include-file {infile mapping} {
 			if {$condtype ne "if"} {
 				if {[llength $condstack] <= 1} {
 					autosetup-error "$infile:$linenum: Error: @$condtype missing @if"
-				} elseif {[string length $condargs]} {
+				} elseif {[string length $condargs] && [string index $condargs 0] ne "#"} {
 					autosetup-error "$infile:$linenum: Error: Extra arguments after @$condtype"
 				}
 			}


### PR DESCRIPTION
Commit bf3d739f99ea3d3d7ce58f85d589ff681b746f74 has introduced stricter checks on the syntax of @if/@else/@endif lines in makefile templates, including disallowing anything but spaces after @else/@endif instructions.

This commit proposes to relax this constraint so that comments are allowed. A typical use case is:

```make
@if HAVE_FEATURE
...
@if INNER1
..
..
@endif
..
..
@if INNER2
..
..
@endif
...
...
@endif # HAVE_FEATURE
```