### PR TITLE
Print location of found tclsh

### DIFF
--- a/autosetup
+++ b/autosetup
@@ -213,6 +213,7 @@ proc main {argv} {
 
 	# Log how we were invoked
 	configlog "Invoked as: [getenv WRAPPER $::argv0] [quote-argv $autosetup(argv)]"
+	configlog "Tclsh: [info nameofexecutable]"
 
 	# Note that auto.def is *not* loaded in the global scope
 	source $autosetup(autodef)

--- a/lib/install.tcl
+++ b/lib/install.tcl
@@ -165,9 +165,7 @@ WRAPPER="$0"; export WRAPPER; "autosetup" "$@"
 		writefile configure \
 {#!/bin/sh
 dir="`dirname "$0"`/autosetup"
-tclsh=`"$dir/autosetup-find-tclsh"`
-echo "Tclsh: $tclsh"
-WRAPPER="$0"; export WRAPPER; exec "$tclsh" "$dir/autosetup" "$@"
+WRAPPER="$0"; export WRAPPER; exec "`"$dir/autosetup-find-tclsh"`" "$dir/autosetup" "$@"
 }
 	}
 	catch {exec chmod 755 configure}

--- a/lib/install.tcl
+++ b/lib/install.tcl
@@ -165,7 +165,9 @@ WRAPPER="$0"; export WRAPPER; "autosetup" "$@"
 		writefile configure \
 {#!/bin/sh
 dir="`dirname "$0"`/autosetup"
-WRAPPER="$0"; export WRAPPER; exec "`"$dir/autosetup-find-tclsh"`" "$dir/autosetup" "$@"
+tclsh=`"$dir/autosetup-find-tclsh"`
+echo "Tclsh: $tclsh"
+WRAPPER="$0"; export WRAPPER; exec "$tclsh" "$dir/autosetup" "$@"
 }
 	}
 	catch {exec chmod 755 configure}


### PR DESCRIPTION
It is sometimes useful to be able to figure which Tcl shell autosetuo is using. How about printing the result of autosetup-find-tclsh at startup?