### PR TITLE
Add transformation options to backwards-compatibility list

### DIFF
--- a/lib/system.tcl
+++ b/lib/system.tcl
@@ -52,6 +52,9 @@ options {
 	maintainer-mode=0
 	dependency-tracking=0
 	silent-rules=0
+	program-prefix:
+	program-suffix:
+	program-transform-name:
 }
 
 # @check-feature name { script }


### PR DESCRIPTION
Some build systems (namely, Fedora) will add an empty --program-prefix
to configure invocations. Would it make sense to support this bunch?
https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Transformation-Options.html