### PR TITLE
accept but ignore --x-includes/--x-libraries

### DIFF
--- a/lib/system.tcl
+++ b/lib/system.tcl
@@ -55,6 +55,8 @@ options {
 	program-prefix:
 	program-suffix:
 	program-transform-name:
+	x-includes:
+	x-libraries:
 }
 
 # @check-feature name { script }


### PR DESCRIPTION
for more seamless migration from autoconf to autosetup

Encountered in the wild with sqlite switching to autosetup when packaging it in RPM distribution having generic `%configure` macro making use of these options.