### PR TITLE
build: make local const

### DIFF
--- a/jimsh0.c
+++ b/jimsh0.c
@@ -2626,7 +2626,7 @@ static int aio_cmd_gets(Jim_Interp *interp, int argc, Jim_Obj *const *argv)
     int len;
     int nb;
     unsigned flags = AIO_ONEREAD;
-    char *nl = NULL;
+    const char *nl = NULL;
     int offset = 0;
 
     errno = 0;


### PR DESCRIPTION
Trivial build fix.

A recent build on Fedora 44 (rawhide) failed here (but F43, F42 and EPEL9 were fine).
My guess is some new build-hardening settings.
